### PR TITLE
fix error that occurs in updated window sdk

### DIFF
--- a/PhotonBeam/PhotonBeamApp.cpp
+++ b/PhotonBeam/PhotonBeamApp.cpp
@@ -94,6 +94,7 @@ PhotonBeamApp::PhotonBeamApp(HINSTANCE hInstance):
     m_airScatterCoff = XMVECTORF32{};
     m_airExtinctCoff = XMVECTORF32{};
     m_sourceLight = XMVECTORF32{};
+    m_camearaFOV = 60.0f;
 
     for (size_t i = 0; i < to_underlying(RootSignatueEnums::BeamTrace::ERootSignatures::Count); i++)
     {


### PR DESCRIPTION
fix the error that occurs after updating visual studio.
Probably due to updated windows sdk?

The error is caused when `XMMatrixPerspectiveFovLH` function in `DirectXMathMatrix.inl` file is called with zero angle.

The error occurs only in Debug mode due to assertion check.